### PR TITLE
Extend get_output_path to try using counterpart files

### DIFF
--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -40,7 +40,7 @@ class PlannerTestCase(unittest.TestCase):
             ('DSC_064662.NEF', '2009/01/090106/DSC_064662.NEF'),
             ('IMG_6828.JPG', '2019/04/190430/CLK_jv3vijqe.JPG'),
             ('IMG_9895.JPG', '2020/03/200320/CLK_k80cid1l.JPG'),
-            # ('IMG_9895.MOV', '2020/03/200320/IMG_9895.MOV'),
+            ('IMG_9895.MOV', '2020/03/200320/CLK_k80cid1l.MOV'),
             ('IMG_054762.JPG', '2006/10/061025/IMG_054762.JPG'),
             ('JYBF8578.DNG', '2020/10/201018/CLK_kgex8fen.DNG'),
         ]


### PR DESCRIPTION
Enables renaming of counterpart files with less EXIF (i.e. movies)

Fixes #2 